### PR TITLE
feat(profile): fix parameter encodings and add colorspace/kelvin/iopcode

### DIFF
--- a/src/rawji/fuji_enums.py
+++ b/src/rawji/fuji_enums.py
@@ -238,6 +238,12 @@ class ColorChromeBlue(IntEnum):
     Strong = 0x2
 
 
+class ColorSpace(IntEnum):
+    """Output colour space (sets the JPEG's EXIF ColorSpace tag)."""
+    sRGB = 0x1
+    AdobeRGB = 0x2
+
+
 # ==============================================================================
 # Exposure Bias Constants
 # ==============================================================================
@@ -258,7 +264,9 @@ def ev_to_int(ev: float) -> int:
     """Convert EV float to int32 for profile (-5.0 to +5.0)"""
     if ev < -5.0 or ev > 5.0:
         raise ValueError(f"Exposure bias out of range: {ev} EV (must be -5.0 to +5.0)")
-    return int(ev * 1000)
+    # Round, not truncate: 2/3 EV is 0.6667 -> 667, not 666. The camera
+    # rejects off-by-one codes for some 1/3-stop steps.
+    return round(ev * 1000)
 
 
 def int_to_ev(value: int) -> float:
@@ -323,6 +331,20 @@ def validate_color_temp(value: int) -> int:
     if value < 2500 or value > 10000:
         raise ValueError(f"Color temperature out of range: {value}K (must be 2500K to 10000K)")
     return value
+
+
+# The camera honors ONLY these exact Kelvin presets for Temperature WB; any
+# other value falls back to the coolest.
+WB_KELVIN_PRESETS = (
+    2500, 2550, 2650, 2700, 2800, 2850, 2950, 3000, 3100, 3200, 3300,
+    3400, 3600, 3700, 3800, 4000, 4200, 4300, 4500, 4800, 5000, 5300,
+    5600, 5900, 6300, 6700, 7100, 7700, 8300, 9100, 10000,
+)
+
+
+def nearest_color_temp(value: int) -> int:
+    """Snap a Kelvin value to the nearest preset the camera honors."""
+    return min(WB_KELVIN_PRESETS, key=lambda preset: abs(preset - value))
 
 
 # ==============================================================================
@@ -415,8 +437,10 @@ FUJIFILM_USB_VENDOR_ID = 0x04CB  # Fuji Photo Film Co., Ltd
 
 # Known Fujifilm PTP camera PIDs
 FUJIFILM_CAMERA_PIDS = [
+    0x02D1,  # X100F
+    0x02DD,  # X-T3
     0x02E3,  # X-T30
-    0x02E5,  # X-T3
+    0x02E5,  # X-T3 (variant)
     0x02E7,  # X-T4
     # Add more as discovered
 ]

--- a/src/rawji/fuji_profile.py
+++ b/src/rawji/fuji_profile.py
@@ -41,6 +41,58 @@ def decode_tone_value(encoded: int) -> int:
         encoded = encoded - 0x100000000
     return encoded // 10
 
+NOISE_REDUCTION_CODES = {
+    4: 0x5000,
+    3: 0x6000,
+    2: 0x0,
+    1: 0x1000,
+    0: 0x2000,
+    -1: 0x3000,
+    -2: 0x4000,
+    -3: 0x7000,
+    -4: 0x8000,
+}
+_NOISE_REDUCTION_LEVELS = {
+    code: level for level, code in NOISE_REDUCTION_CODES.items()
+}
+
+def encode_noise_reduction(level: int) -> int:
+    """Encode a noise-reduction level (-4 to +4) to its d185 code"""
+    try:
+        return NOISE_REDUCTION_CODES[level]
+    except KeyError:
+        raise ValueError(
+            f"NoiseReduction out of range: {level} (must be -4 to +4)"
+        )
+
+def decode_noise_reduction(code: int) -> int:
+    """Decode a d185 noise-reduction code to a level (0 if unrecognised)"""
+    return _NOISE_REDUCTION_LEVELS.get(code, 0)
+
+def read_iopcode(profile: bytes) -> Optional[int]:
+    """Read the IOPCode (processor id) from a profile header, or None."""
+    if len(profile) <= 3:
+        return None
+    char_count = profile[2]
+    chars = []
+    offset = 3
+    for _ in range(max(0, char_count)):
+        if offset + 2 > len(profile):
+            return None
+        code = struct.unpack_from('<H', profile, offset)[0]
+        offset += 2
+        if code == 0:
+            break
+        chars.append(chr(code))
+    try:
+        return int(''.join(chars), 16)
+    except ValueError:
+        return None
+
+def is_xprocessor5(iopcode: int) -> bool:
+    """Whether an IOPCode identifies an XProcessor5 body."""
+    return (iopcode & 0x00FFFF00) == 0x00179500
+
 # ==============================================================================
 # Profile Parameter Indices (Standard Format)
 # ==============================================================================
@@ -65,7 +117,7 @@ PARAM_INDEX = {
     'ShadowTone': 16,         # ← Works with *10 encoding! (X-T30: -2 to +4)
     'Color': 17,              # ← Works with *10 encoding!
     'Sharpness': 18,          # ← Works with *10 encoding!
-    'NoiseReduction': 19,     # ← Should work with *10 encoding
+    'NoiseReduction': 19,     # ← NOT *10 (see encode_noise_reduction)
     'Clarity': 20,
     'ColorSpace': 21,
     'HDR': 22,
@@ -81,7 +133,7 @@ PARAM_INDEX = {
 INDEX_TO_PARAM = {v: k for k, v in PARAM_INDEX.items()}
 
 # Parameters that use *10 encoding
-TONE_PARAMS = {'HighlightTone', 'ShadowTone', 'Color', 'Sharpness', 'NoiseReduction', 'Clarity'}
+TONE_PARAMS = {'HighlightTone', 'ShadowTone', 'Color', 'Sharpness', 'Clarity'}
 
 # ==============================================================================
 # Profile Creation
@@ -169,6 +221,12 @@ def create_profile_from_camera(
             value = params[param_name]
             params[param_name] = encode_tone_value(value)
 
+    # NoiseReduction uses its own code table (not *10)
+    if 'NoiseReduction' in params:
+        params['NoiseReduction'] = encode_noise_reduction(
+            params['NoiseReduction']
+        )
+
     # Write parameters at offset 0x201
     for i in range(NUM_PARAMS):
         param_name = INDEX_TO_PARAM[i]
@@ -209,7 +267,9 @@ def create_profile_simple(
     """
     changes = {
         'FilmSimulation': film_sim,
-        'ExposureBias': int(exposure * 1000),  # Convert EV to millistops
+        # Round, not truncate: 2/3 EV is 0.6667 -> 667, not 666 (the camera
+        # rejects off-by-one codes for some 1/3-stop steps).
+        'ExposureBias': round(exposure * 1000),
         'HighlightTone': highlights,
         'ShadowTone': shadows,
         'Color': color,
@@ -247,6 +307,8 @@ def parse_profile(data: bytes) -> Dict[str, int]:
         # Decode tone parameters
         if param_name in TONE_PARAMS:
             value = decode_tone_value(value)
+        elif param_name == 'NoiseReduction':
+            value = decode_noise_reduction(value)
 
         params[param_name] = value
 


### PR DESCRIPTION
- NoiseReduction uses its own code table, not *10 — it was silently ignored. Added encode/decode_noise_reduction.
- ExposureBias now rounds instead of truncating (2/3 EV -> 667, not 666).
- Added ColorSpace enum, WB Kelvin presets + nearest_color_temp(), and read_iopcode()/is_xprocessor5().