### PR TITLE
feat: add mono tone controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ exposure, tone curve, and more!
 
 - **All Film Simulations** - Provia, Velvia, Acros, Classic Chrome, Eterna, and more
 - **Complete Tone Control** - Sharpness, Highlights, Shadows, Color/Saturation
-- **Exposure Adjustment** - ±5.0 EV in 1/3 stop increments
+- **Exposure Adjustment** - -2.0 to +3.0 EV in 1/3 stops (honored range)
 - **Dynamic Range** - DR100, DR200, DR400
 - **White Balance** - Full control including temperature and RGB shift
 
@@ -75,25 +75,46 @@ rawji photo.RAF converted.jpg \
 A film simulation must exist on the camera doing the conversion. The
 engine renders unknown codes as Provia.
 
+### White Balance Options
+
+- `asshot` - Keep the RAF's own white balance (default when unset)
+- `auto` - Automatic white balance
+- `daylight` - Daylight
+- `shade` - Shade
+- `incandescent` - Incandescent / tungsten
+- `fluorescent1` / `fluorescent2` / `fluorescent3` - Fluorescent
+- `underwater` - Underwater
+- `temperature` - Manual color temperature, set the value with `--wb-temp`
+- `custom1` / `custom2` / `custom3` - Custom presets measured on the camera
+
+Any preset can be fine-tuned with `--wb-shift-r` and `--wb-shift-b`. The
+manual `temperature` mode honors only the camera's Kelvin presets on
+older bodies, but any value from 2500 to 10000 K on XProcessor5 bodies.
+
 ### Parameter Reference
 
-| Parameter         | Range               | Description                   |
-|-------------------|---------------------|-------------------------------|
-| `--film-sim`      | See above           | Film simulation mode          |
-| `--exposure`      | -5.0 to +5.0        | Exposure bias in EV           |
-| `--highlights`    | -4 to +4            | Highlight tone adjustment     |
-| `--shadows`       | -2 to +4            | Shadow tone (X-T30: -2 to +4) |
-| `--sharpness`     | -4 to +4            | Sharpness (-4=soft, +4=hard)  |
-| `--color`         | -4 to +4            | Color saturation/intensity    |
-| `--nr`            | -4 to +4            | Noise reduction               |
-| `--clarity`       | -5 to +5            | Clarity (newer bodies only)   |
-| `--grain`         | off/weak/strong     | Film grain effect             |
-| `--grain-size`    | small/large         | Grain size                    |
-| `--color-chrome`  | off/weak/strong     | Color chrome effect           |
+| Parameter         | Range             | Description                   |
+|-------------------|-------------------|-------------------------------|
+| `--film-sim`      | See above         | Film simulation mode          |
+| `--exposure`      | -2.0 to +3.0      | Exposure bias in EV (1/3 stops) |
+| `--highlights`    | -2 to +4          | Highlight tone adjustment     |
+| `--shadows`       | -2 to +4          | Shadow tone (X-T30: -2 to +4) |
+| `--sharpness`     | -4 to +4          | Sharpness (-4=soft, +4=hard)  |
+| `--color`         | -4 to +4          | Color saturation/intensity    |
+| `--nr`            | -4 to +4          | Noise reduction               |
+| `--clarity`       | -5 to +5          | Clarity (newer bodies only)   |
+| `--grain`         | off/weak/strong   | Film grain effect             |
+| `--grain-size`    | small/large       | Grain size                    |
+| `--color-chrome`  | off/weak/strong   | Color chrome effect           |
 | `--color-chrome-blue` | off/weak/strong | Color chrome FX blue          |
-| `--smooth-skin`   | off/weak/strong     | Smooth skin effect            |
-| `--dynamic-range` | 100/200/400         | Dynamic range setting         |
-| `--white-balance` | auto/daylight/shade | White balance preset          |
+| `--smooth-skin`   | off/weak/strong   | Smooth skin effect            |
+| `--dynamic-range` | 100/200/400       | Dynamic range setting         |
+| `--white-balance` | See above         | White balance mode            |
+| `--wb-shift-r`    | -9 to +9          | WB shift, red-cyan axis       |
+| `--wb-shift-b`    | -9 to +9          | WB shift, blue-yellow axis    |
+| `--wb-temp`       | 2500 to 10000 K   | Kelvin (needs `temperature`)  |
+| `--mono-wc`       | ±9 gen4 / ±18 XProc5 | Mono warm-cool (B&W sims)    |
+| `--mono-mg`       | ±18 XProc5   | Mono magenta-green (B&W sims) |
 
 ## Examples
 

--- a/src/rawji/__main__.py
+++ b/src/rawji/__main__.py
@@ -78,7 +78,7 @@ Requirements:
         '--exposure',
         type=float,
         metavar='EV',
-        help='Exposure bias in EV (-5.0 to +5.0)'
+        help='Exposure bias in EV (-2.0 to +3.0, 1/3 stops)'
     )
 
     # Tone curve
@@ -119,6 +119,18 @@ Requirements:
         type=int,
         metavar='N',
         help='Clarity (-5 to +5)'
+    )
+    parser.add_argument(
+        '--mono-wc',
+        type=int,
+        metavar='N',
+        help='Mono warm-cool, B&W sims (+-9 gen4, +-18 XProcessor5)'
+    )
+    parser.add_argument(
+        '--mono-mg',
+        type=int,
+        metavar='N',
+        help='Mono magenta-green, B&W sims, XProcessor5 only (+-18)'
     )
 
     # White balance
@@ -267,6 +279,15 @@ Requirements:
         if args.clarity is not None:
             changes['Clarity'] = args.clarity
             print(f"Clarity: {args.clarity:+d}")
+
+        # Monochromatic Color
+        if args.mono_wc is not None:
+            changes['BlackImageTone'] = args.mono_wc
+            print(f"Mono WC: {args.mono_wc:+d}")
+
+        if args.mono_mg is not None:
+            changes['MonochromaticColorRG'] = args.mono_mg
+            print(f"Mono MG: {args.mono_mg:+d}")
 
         # White balance
         if args.white_balance:

--- a/src/rawji/__main__.py
+++ b/src/rawji/__main__.py
@@ -86,7 +86,7 @@ Requirements:
         '--highlights',
         type=int,
         metavar='N',
-        help='Highlight tone (-4 to +4)'
+        help='Highlight tone (-2 to +4)'
     )
     parser.add_argument(
         '--shadows',

--- a/src/rawji/fuji_profile.py
+++ b/src/rawji/fuji_profile.py
@@ -351,8 +351,8 @@ def validate_params(
     if exposure is not None and (exposure < -2.0 or exposure > 3.0):
         raise ValueError(f"Exposure out of range: {exposure} (must be -2.0 to +3.0 EV)")
 
-    if highlights is not None and (highlights < -4 or highlights > 4):
-        raise ValueError(f"Highlights out of range: {highlights} (must be -4 to +4)")
+    if highlights is not None and (highlights < -2 or highlights > 4):
+        raise ValueError(f"Highlights out of range: {highlights} (must be -2 to +4)")
 
     # X-T30 shadow tone is limited to -2 to +4
     if shadows is not None and (shadows < -2 or shadows > 4):

--- a/src/rawji/fuji_profile.py
+++ b/src/rawji/fuji_profile.py
@@ -120,10 +120,10 @@ PARAM_INDEX = {
     'NoiseReduction': 19,     # ← NOT *10 (see encode_noise_reduction)
     'Reserved20': 20,
     'ColorSpace': 21,
-    'HDR': 22,
+    'BlackImageTone': 22,
     'SmoothSkinEffect': 23,
     'ColorChromeBlue': 24,
-    'Reserved25': 25,
+    'MonochromaticColorRG': 25,
     'Clarity': 26,            # *10 encoding
     'Reserved27': 27,
     'Reserved28': 28,
@@ -133,7 +133,10 @@ PARAM_INDEX = {
 INDEX_TO_PARAM = {v: k for k, v in PARAM_INDEX.items()}
 
 # Parameters that use *10 encoding
-TONE_PARAMS = {'HighlightTone', 'ShadowTone', 'Color', 'Sharpness', 'Clarity'}
+TONE_PARAMS = {
+    'HighlightTone', 'ShadowTone', 'Color', 'Sharpness', 'Clarity',
+    'BlackImageTone', 'MonochromaticColorRG',
+}
 
 # ==============================================================================
 # Profile Creation
@@ -202,10 +205,10 @@ def create_profile_from_camera(
         'NoiseReduction': 0,
         'Reserved20': 0,
         'ColorSpace': 0,
-        'HDR': 0,
+        'BlackImageTone': 0,
         'SmoothSkinEffect': 0,
         'ColorChromeBlue': 0,
-        'Reserved25': 0,
+        'MonochromaticColorRG': 0,
         'Clarity': 0,
         'Reserved27': 0,
         'Reserved28': 0,
@@ -337,14 +340,16 @@ def validate_params(
     shadows: Optional[int] = None,
     color: Optional[int] = None,
     sharpness: Optional[int] = None,
+    warm_cool: Optional[int] = None,
+    magenta_green: Optional[int] = None,
 ) -> None:
     """Validate parameter ranges"""
 
     if film_sim is not None and (film_sim < 0x1 or film_sim > 0x14):
         raise ValueError(f"FilmSimulation out of range: 0x{film_sim:02X} (must be 0x01-0x14)")
 
-    if exposure is not None and (exposure < -5.0 or exposure > 5.0):
-        raise ValueError(f"Exposure out of range: {exposure} (must be -5.0 to +5.0 EV)")
+    if exposure is not None and (exposure < -2.0 or exposure > 3.0):
+        raise ValueError(f"Exposure out of range: {exposure} (must be -2.0 to +3.0 EV)")
 
     if highlights is not None and (highlights < -4 or highlights > 4):
         raise ValueError(f"Highlights out of range: {highlights} (must be -4 to +4)")
@@ -358,6 +363,14 @@ def validate_params(
 
     if sharpness is not None and (sharpness < -4 or sharpness > 4):
         raise ValueError(f"Sharpness out of range: {sharpness} (must be -4 to +4)")
+
+    if warm_cool is not None and (warm_cool < -18 or warm_cool > 18):
+        raise ValueError(f"WarmCool out of range: {warm_cool} (must be -18 to +18)")
+
+    if magenta_green is not None and (magenta_green < -18 or magenta_green > 18):
+        raise ValueError(
+            f"MagentaGreen out of range: {magenta_green} (must be -18 to +18)"
+        )
 
 
 def dump_profile(profile: bytes) -> str:


### PR DESCRIPTION
- Add support for monochromatic warm-cool and magenta-green controls
- Adjust exposure range to -2.0 to +3.0 EV in 1/3 stops
- Expand white balance options and refine parameter documentation in README